### PR TITLE
fix: add missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ passport.use(new Amebame.Strategy({
   scope: '', // Optional
   authOrigin: '', // Optional
   profileOrigin: '', // Optional
-}, function(accessToken, refreshToken, profile, done) {
+}, function(accessToken, refreshToken, params, profile, done) {
   User.findOrCreate({ id: profile.id, profile }, function(err, user) {
     if (err) { return done(err); }
     done(null, user);

--- a/lib/passport-amebame/index.d.ts
+++ b/lib/passport-amebame/index.d.ts
@@ -20,6 +20,12 @@ interface IStrategyOption {
   profileOrigin?: string;
 }
 
+interface IVerifyParams {
+  access_token: string;
+  as_id: string;
+  expires_in: string;
+}
+
 interface IAuthorizationParams {
   frm_id?: string;
   ameba_frmId?: string;
@@ -33,7 +39,7 @@ interface IAuthorizationParams {
 
 export class Strategy extends passport.Strategy {
   constructor(options: IStrategyOption,
-      verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: Error | null, user?: Express.User) => void) => void);
+      verify: (accessToken: string, refreshToken: string, params: IVerifyParams, profile: Profile, done: (error: Error | null, user?: Express.User) => void) => void);
 
   name: string;
   authenticate(req: express.Request, options?: Object): void;

--- a/test/type-tests.ts
+++ b/test/type-tests.ts
@@ -14,7 +14,7 @@ const CLIENT_SECRET = '';
 passport.use(new Amebame.Strategy({
   clientID: CLIENT_ID,
   clientSecret: CLIENT_SECRET,
-}, function(accessToken, refreshToken, profile, done) {
+}, function(accessToken, refreshToken, params, profile, done) {
   User.findOrCreate(accessToken, refreshToken, profile.id, profile.provider, function(err, user) {
     if (err) { return done(err); }
     done(null, user);
@@ -26,7 +26,7 @@ passport.use(new Amebame.Strategy({
   clientSecret: CLIENT_SECRET,
   authOrigin: 'https://sb.dauth.user.ameba.jp',
   profileOrigin: 'https//sb-profile-api.ameba.jp',
-}, function(accessToken, refreshToken, profile, done) {
+}, function(accessToken, refreshToken, params, profile, done) {
   User.findOrCreate(accessToken, refreshToken, profile.id, profile.provider, function(err, user) {
     if (err) { return done(err); }
     done(null, user);


### PR DESCRIPTION
元の実装から不必要な変更をしていたので、戻しました。`params`は新しいAPIでも同様に返ってきていました。

ref: #4 