### PR TITLE
type: add Profile type definition

### DIFF
--- a/lib/passport-amebame/index.d.ts
+++ b/lib/passport-amebame/index.d.ts
@@ -1,6 +1,44 @@
 import passport = require('passport');
 import express = require('express');
 
+type ProfilePrivacy = 'anonymous' | 'everyone' | 'onlyMe';
+
+type ProfileJson = {
+  id: {
+    amebaId: string,
+    asId: string,
+  },
+  time: {
+    create: string,
+    update: string,
+  },
+  nickname: {
+    value: string,
+    censored: boolean,
+  },
+  gender: {
+    value: string,
+    privacy: ProfilePrivacy
+  },
+  birthday: {
+    value: string,
+    privacy: ProfilePrivacy,
+    changed: boolean,
+  },
+  profileImage: {
+    originUrl: string,
+    thumbnailUrl: string,
+    censored: boolean,
+    exists: boolean,
+    meta: {
+      amebaOriginWidth: number,
+      amebaOriginHeight: number,
+      amebaThumbnailWidth: number,
+      amebaThumbnailHeight: number,
+    },
+  }
+};
+
 interface Profile extends passport.Profile {
   id: string;
   displayName: string;
@@ -9,7 +47,7 @@ interface Profile extends passport.Profile {
   birthday?: string;
 
   _raw: string;
-  _json: any;
+  _json: ProfileJson;
 }
 
 interface IStrategyOption {


### PR DESCRIPTION
passport-amebameではProfile APIから取得するデータを固定しているので、そちらにも型定義を追加しました。

https://github.com/openameba/passport-amebame/blob/70825fb5cd1ac2f8ca6057145ea3088a4205a707/lib/passport-amebame/strategy.js#L37